### PR TITLE
Added option to specify path to neural net model

### DIFF
--- a/katago-analyze-sgf-daemon.js
+++ b/katago-analyze-sgf-daemon.js
@@ -125,23 +125,25 @@ class Engine extends EventEmitter {
     if (this.katago && !this.katago.killed) {
       return
     }
+    let katagoArgs
     if (this.modelPath == null) {
-      this.katago = spawn(this.katagoPath, [
+      katagoArgs = [
         'analysis',
         '-config',
         this.analysisConfig,
         '-quit-without-waiting',
-      ])
+      ]
     } else {
-      this.katago = spawn(this.katagoPath, [
-	'analysis',
-	'-config',
-	this.analysisConfig,
-	'-model',
-	this.modelPath,
-	'-quit-without-waiting',
-    ])
+      katagoArgs = [
+        'analysis',
+        '-config',
+        this.analysisConfig,
+        '-model',
+        this.modelPath,
+        '-quit-without-waiting',
+      ]
     }
+    this.katago = spawn(this.katagoPath, katagoArgs)
     this.katago.stdout.on('readable', () => {
       // copy data into buffer
       let data
@@ -440,9 +442,16 @@ function main() {
     }
   ).argv
 
-  const {ANALYSIS_CONFIG, port, katagoPath, modelPath, sourceDir, destinationDir} = argv
+  const {
+    ANALYSIS_CONFIG,
+    port,
+    katagoPath,
+    modelPath,
+    sourceDir,
+    destinationDir,
+  } = argv
 
-    const engine = new Engine(katagoPath, ANALYSIS_CONFIG, modelPath)
+  const engine = new Engine(katagoPath, ANALYSIS_CONFIG, modelPath)
 
   engine.start()
 

--- a/katago-analyze-sgf-daemon.js
+++ b/katago-analyze-sgf-daemon.js
@@ -125,23 +125,14 @@ class Engine extends EventEmitter {
     if (this.katago && !this.katago.killed) {
       return
     }
-    let katagoArgs
-    if (this.modelPath == null) {
-      katagoArgs = [
-        'analysis',
-        '-config',
-        this.analysisConfig,
-        '-quit-without-waiting',
-      ]
-    } else {
-      katagoArgs = [
-        'analysis',
-        '-config',
-        this.analysisConfig,
-        '-model',
-        this.modelPath,
-        '-quit-without-waiting',
-      ]
+    let katagoArgs = [
+      'analysis',
+      '-config',
+      this.analysisConfig,
+      '-quit-without-waiting',
+    ]
+    if (this.modelPath != null) {
+      katagoArgs.push('-model', this.modelPath)
     }
     this.katago = spawn(this.katagoPath, katagoArgs)
     this.katago.stdout.on('readable', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "katago-analyze-sgf",
-  "version": "0.1.1",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "katago-analyze-sgf",
-      "version": "0.1.1",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@sabaki/sgf": "^3.4.7",
@@ -1186,9 +1186,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -2494,9 +2494,9 @@
       }
     },
     "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "katago-analyze-sgf",
-  "version": "0.0.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "katago-analyze-sgf",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@sabaki/sgf": "^3.4.7",
@@ -1186,9 +1186,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -2494,9 +2494,9 @@
       }
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"


### PR DESCRIPTION
I added an option `model-path` to the daemon; this allows the user to have the neural network model in a different directory than the katago binary.  If the model path is not specified (defaulting to null), the `Engine` constructs the katago command exactly as it did before.